### PR TITLE
Remove pytest-runner dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(name='binpacking',
       author_email='bfmaier@physik.hu-berlin.de',
       license='MIT',
       packages=['binpacking'],
-      setup_requires=['pytest-runner'],
       install_requires=[
           'future',
       ],


### PR DESCRIPTION
The dependency on the pytest-runner package introduces some security risks and as such has been deprecated.

From pytest-runner pypi:
   pytest-runner depends on deprecated features of setuptools and relies on features that break security mechanisms in pip.
   For example ‘setup_requires’ and ‘tests_require’ bypass pip --require-hashes. See also pypa/setuptools#1684.

   It is recommended that you:
    Remove 'pytest-runner' from your setup_requires, preferably removing the setup_requires option.
    Remove 'pytest' and any other testing requirements from tests_require, preferably removing the tests_requires option.
    Select a tool to bootstrap and then run tests such as tox