### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,5 +10,5 @@ max-line-length = 120
 exclude = __init__.py
 
 [metadata]
-long-description = file: README.rst
+long_description = file: README.rst
 license = MIT


### PR DESCRIPTION
 Invalid dash-separated key 'long-description' in 'metadata' (setup.cfg), please use the underscore name 'long_description' instead